### PR TITLE
Update YoutubePlugin.ts to fix infinite loading on errored tracks

### DIFF
--- a/packages/core/src/plugins/stream/YoutubePlugin.ts
+++ b/packages/core/src/plugins/stream/YoutubePlugin.ts
@@ -16,7 +16,11 @@ class YoutubePlugin extends StreamProviderPlugin {
   async search(query: StreamQuery): Promise<undefined | StreamData[]> {
     const terms = query.artist + ' ' + query.track;
     try {
-      return Youtube.trackSearch(query, this.sourceName);
+      const tracks = await Youtube.trackSearch(query);
+
+      return Promise.all(tracks.map(async track => {              
+        return track;
+      }));
     } catch (e) {
       logger.error(`Error while searching  for ${terms} on Youtube`);
       logger.error(e);
@@ -25,11 +29,11 @@ class YoutubePlugin extends StreamProviderPlugin {
 
   async getStreamForId(id: string): Promise<undefined | StreamData> {
     try {
-      return Youtube.getStreamForId(id, this.sourceName);
+      const stream = await Youtube.getStreamForId(id, this.sourceName);
+      return stream;
     } catch (e) {
       logger.error(`Error while looking up streams for id: ${id} on Youtube`);
-      logger.error(e);
-      
+      logger.error(e);      
     }
   }
 }


### PR DESCRIPTION
Updated YoutubePlugin to handle erred tracks the same way BandcampPlugin handles it. When a track search results in an error, the plugin doesn't return a Promise that causes the track to keep loading infinitely and block the queue from continuing to next track, instead the track gets automatically removed from the queue since the StreamData is invalid. This keeps the queue clear of any erred tracks.

Note: This does not handle tracks that have age restrictions or other Youtube policies applied to them that require the user to manually click a button, for example self harm disclaimer. This most likely needs to be addressed by YoutubeHeuristics.